### PR TITLE
Updates to allow playground book to run in Playgrounds Version 4.1 (1676.15)

### DIFF
--- a/Talking To The Live View.playgroundbook/Contents/Manifest.plist
+++ b/Talking To The Live View.playgroundbook/Contents/Manifest.plist
@@ -10,6 +10,8 @@
 	<string>1</string>
 	<key>DeploymentTarget</key>
 	<string>ios10.0</string>
+	<key>SwiftVersion</key>
+	<string>4.2</string>
 	<key>Name</key>
 	<string>Talking to the Live View</string>
 	<key>ImageReference</key>

--- a/Talking To The Live View.playgroundbook/Contents/Sources/FaceViewController.swift
+++ b/Talking To The Live View.playgroundbook/Contents/Sources/FaceViewController.swift
@@ -46,7 +46,7 @@ public class FaceViewController: UIViewController, UIGestureRecognizerDelegate {
         faceView.translatesAutoresizingMaskIntoConstraints = true
         faceView.layer.masksToBounds = true
         faceView.layer.cornerRadius = 10
-        visualEffectView.addSubview(faceView)
+        visualEffectView.contentView.addSubview(faceView)
 
         tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.tapped))
         tapGesture.delegate = self

--- a/Talking To The Live View.playgroundbook/Contents/Sources/JokePattern.swift
+++ b/Talking To The Live View.playgroundbook/Contents/Sources/JokePattern.swift
@@ -55,7 +55,7 @@ public extension JokePattern {
      This enum provides specific error information if something goes wrong
      converting from a `PlaygroundValue` into a `JokePattern`.`
      */
-    public enum SerializationError: Error {
+    enum SerializationError: Error {
         case valueNotADictionary
         case missingSetupString
         case missingPunchlineString


### PR DESCRIPTION
Your playground book was essential to building my understanding of how to communicate with a live view (I used it to build out [an interactive drawing playground book](https://github.com/russellgordon/TortoiseDrawingPlaygroundBook)).

This pull request contains a few modest updates that I was able to figure out that allowed me to open your playground book and learn from it.